### PR TITLE
changed from dual_bank to single_bank

### DIFF
--- a/variants/Simblee/ota_bootloader.h
+++ b/variants/Simblee/ota_bootloader.h
@@ -19,7 +19,7 @@
 #include "Arduino.h"
 
 #ifndef OTA_BOOTLOADER_TYPE
-#define  OTA_BOOTLOADER_TYPE  dual_bank
+#define  OTA_BOOTLOADER_TYPE  single_bank  //  dual_bank
 #endif
 
 // force double expansion


### PR DESCRIPTION
dual_bank has application file size limit, while single_bank does not.
Only risk is that during upload something gets corrupted... Good thing we have the breakout header!